### PR TITLE
Fixing permission for accessing css/js

### DIFF
--- a/PJS.Bootstrap.csproj
+++ b/PJS.Bootstrap.csproj
@@ -211,27 +211,27 @@
     <Content Include="Placement.info" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Orchard\Orchard.Framework.csproj">
+    <ProjectReference Include="..\..\..\..\Orchard\Orchard.Framework.csproj">
       <Project>{2D1D92BB-4555-4CBE-8D0E-63563D6CE4C6}</Project>
       <Name>Orchard.Framework</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Orchard.Web\Core\Orchard.Core.csproj">
+    <ProjectReference Include="..\..\..\Core\Orchard.Core.csproj">
       <Project>{9916839C-39FC-4CEB-A5AF-89CA7E87119F}</Project>
       <Name>Orchard.Core</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Comments\Orchard.Comments.csproj">
+    <ProjectReference Include="..\..\..\Modules\Orchard.Comments\Orchard.Comments.csproj">
       <Project>{14c049fd-b35b-415a-a824-87f26b26e7fd}</Project>
       <Name>Orchard.Comments</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Search\Orchard.Search.csproj">
+    <ProjectReference Include="..\..\..\Modules\Orchard.Search\Orchard.Search.csproj">
       <Project>{4be4eb01-ac56-4048-924e-2ca77f509aba}</Project>
       <Name>Orchard.Search</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Tags\Orchard.Tags.csproj">
+    <ProjectReference Include="..\..\..\Modules\Orchard.Tags\Orchard.Tags.csproj">
       <Project>{5d0f00f0-26c9-4785-ad61-b85710c60eb0}</Project>
       <Name>Orchard.Tags</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Orchard.Web\Modules\Orchard.Users\Orchard.Users.csproj">
+    <ProjectReference Include="..\..\..\Modules\Orchard.Users\Orchard.Users.csproj">
       <Project>{79aed36e-abd0-4747-93d3-8722b042454b}</Project>
       <Name>Orchard.Users</Name>
     </ProjectReference>

--- a/Web.config
+++ b/Web.config
@@ -44,7 +44,7 @@
   </system.web>
   <system.webServer>
     <handlers accessPolicy="Script,Read">
-      <add name="StaticFile" path="Theme.png" verb="GET" modules="StaticFileModule" preCondition="integratedMode" resourceType="File" requireAccess="Read" />
+      <add name="StaticThemeImage" path="Theme.png" verb="GET" modules="StaticFileModule" preCondition="integratedMode" resourceType="File" requireAccess="Read" />
     </handlers>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
The fix we submitted previously to show Theme.png img causes css files were inaccessible because I used same name for the handler in web.config used in the root of the theme than the one used for a less restrictive handler in the web.config files within Script and Styles folders.
